### PR TITLE
link to event incorrect

### DIFF
--- a/index.md
+++ b/index.md
@@ -106,7 +106,8 @@ locations:
 
 {% if online == "online" %}
 
-This is an online event. We will meet using the online videoconference software Zoom. You will need to <a href="https://zoom.us/download">download and install their client</a> to connect with your instructors. The link to use for this event is <{{ loc.address }}>.
+This is an online event. We will meet using the online videoconference software Zoom. You will need to <a href="https://zoom.us/download">download and install their client</a> to connect with your instructors. The link to use for this event has been
+sent to all participants by email. Get in touch with us (see Contact section below) if you have any problems.
 
 {% else %}
 {% assign inperson = "true" %}


### PR DESCRIPTION
I have been notified by a learner that the link is set to "FIXME". As I donæt think we want to have a zoom link visible to everyone, I changed the message to tell them to check their email.